### PR TITLE
Add calls to base class _Ready() methods

### DIFF
--- a/Project/Ships/Player/PlayerState.cs
+++ b/Project/Ships/Player/PlayerState.cs
@@ -13,6 +13,8 @@ namespace StarSwarm.Project.Ships.Player
 
         public override async void _Ready()
         {
+            base._Ready();
+            
             await ToSignal(Owner, "ready");
             Ship = (PlayerShip)Owner;
         }

--- a/Project/Ships/Player/States/Move.cs
+++ b/Project/Ships/Player/States/Move.cs
@@ -32,6 +32,8 @@ namespace StarSwarm.Project.Ships.Player.States
 
         public override async void _Ready()
         {
+            base._Ready();
+            
             Agent = new GSAIKinematicBody2DAgent((KinematicBody2D)Owner);
 
             await ToSignal(Owner, "ready");

--- a/Project/Ships/Player/States/Travel.cs
+++ b/Project/Ships/Player/States/Travel.cs
@@ -12,6 +12,8 @@ public class Travel : PlayerState
 
     public override void _Ready()
     {
+        base._Ready();
+        
         AudioThrusters = GetNode<LoopingAudioStreamPlayer2D>("ThrustersAudioPlayer");
     }
 


### PR DESCRIPTION
Fixes a number of errors that were occurring because base classes weren't having their ready methods called.